### PR TITLE
feat: use current URL for OAuth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,4 +2,3 @@
 SUPABASE_URL=""
 # your Supabase Anon Key that you can find under settings/api, e.g eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6IndmenBld21seWlvenVwdWxidXVyIiwicm9sZSI6ImFub24iLCJpYXQiOjE2OTU2NzQzMzksImV4cCI6MjAxMTI1MDMzOX0.SKIL3Q0NOBaMehH0ekFspwgcu3afp3Dl9EDzPqs1nKs
 SUPABASE_ANON_KEY=""
-FRONTEND_URL="http://localhost:8080"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,6 @@ jobs:
           bun install
           bun run build
         env: # Set environment variables for the build
-          FRONTEND_URL: "https://demo.ubq.fi"
           SUPABASE_URL: "https://wfzpewmlyiozupulbuur.supabase.co"
           SUPABASE_ANON_KEY: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6IndmenBld21seWlvenVwdWxidXVyIiwicm9sZSI6ImFub24iLCJpYXQiOjE2OTU2NzQzMzksImV4cCI6MjAxMTI1MDMzOX0.SKIL3Q0NOBaMehH0ekFspwgcu3afp3Dl9EDzPqs1nKs"
 

--- a/build/esbuild-build.ts
+++ b/build/esbuild-build.ts
@@ -40,7 +40,7 @@ export const esBuildContext: esbuild.BuildOptions = {
   outdir: outDir,
   outbase: "static",
   absWorkingDir: process.cwd(),
-  define: createEnvDefines(["SUPABASE_URL", "SUPABASE_ANON_KEY", "FRONTEND_URL"], {
+  define: createEnvDefines(["SUPABASE_URL", "SUPABASE_ANON_KEY"], {
     commitHash: execSync(`git rev-parse --short HEAD`).toString().trim(),
   }),
 };

--- a/static/scripts/demo/auth-context.ts
+++ b/static/scripts/demo/auth-context.ts
@@ -62,7 +62,6 @@ function setEvmSettings(privateKey: string, evmNetwork: number) {
 
 declare const SUPABASE_URL: string;
 declare const SUPABASE_ANON_KEY: string;
-declare const FRONTEND_URL: string;
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 const mainView = document.getElementsByTagName("main")[0];
@@ -157,7 +156,7 @@ export async function gitHubLoginButtonHandler() {
   const { error } = await supabase.auth.signInWithOAuth({
     provider: "github",
     options: {
-      redirectTo: FRONTEND_URL,
+      redirectTo: window.location.href,
       // Request minimum required scope:
       // - public_repo to create public repositories
       scopes: "public_repo",


### PR DESCRIPTION
This PR uses current URL for redirect on github login. It helps for testing on cloudlare preview deployments.