### PR TITLE
fix: updating plugin versions to `demo`

### DIFF
--- a/static/types/default-configuration.yml
+++ b/static/types/default-configuration.yml
@@ -1,18 +1,13 @@
 plugins:
   ubiquity-os-marketplace/command-start-stop@demo:
-    skipBotEvents: false
   ubiquity-os/command-demo@demo:
   ubiquity-os-marketplace/command-wallet@demo:
   ubiquity-os-marketplace/command-query@demo:
-  ubiquity-os-marketplace/text-conversation-rewards@v1.7.9:
-    skipBotEvents: false
+  ubiquity-os-marketplace/text-conversation-rewards@demo:
     with:
       incentives:
         collaboratorOnlyPaymentInvocation: false
-        contentEvaluator:
-          openAi:
-            endpoint: https://openrouter.ai/api/v1
-            model: deepseek/deepseek-r1-0528:free
+        contentEvaluator: {}
         userExtractor: {}
         dataPurge: {}
         formattingEvaluator: {}
@@ -20,12 +15,8 @@ plugins:
         githubComment: {}
         reviewIncentivizer: {}
         simplificationIncentivizer: {}
-        externalContent:
-          llmImageModel:
-            model: meta-llama/llama-4-maverick:free
-          llmWebsiteModel:
-            model: deepseek/deepseek-r1-0528:free
-  ubiquity-os-marketplace/daemon-disqualifier@v1.0.3:
-  ubiquity-os-marketplace/text-vector-embeddings@v1.1.1:
+        externalContent: {}
+  ubiquity-os-marketplace/daemon-disqualifier@demo:
+  ubiquity-os-marketplace/text-vector-embeddings@demo:
     with:
       demoFlag: true

--- a/static/types/default-configuration.yml
+++ b/static/types/default-configuration.yml
@@ -1,5 +1,21 @@
 plugins:
   ubiquity-os-marketplace/command-start-stop@demo:
+    with:
+      taskAccessControl:
+        experience:
+          priorityThresholds:
+            - label: "Priority: 0 (Regression)"
+              minimumXp: 0
+            - label: "Priority: 1 (Normal)"
+              minimumXp: 0
+            - label: "Priority: 2 (Medium)"
+              minimumXp: 0
+            - label: "Priority: 3 (High)"
+              minimumXp: 0
+            - label: "Priority: 4 (Urgent)"
+              minimumXp: 0
+            - label: "Priority: 5 (Emergency)"
+              minimumXp: 0
   ubiquity-os/command-demo@demo:
   ubiquity-os-marketplace/command-wallet@demo:
   ubiquity-os-marketplace/command-query@demo:


### PR DESCRIPTION
Resolves https://github.com/ubiquity-os/command-demo/issues/24

QA: https://github.com/ubiquity-ubiquibot/ubiquity-os-demo-wc23g/issues/1

The account properly received the DEMO tokens as well.

<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
